### PR TITLE
Add support for injecting additional DLLs

### DIFF
--- a/2EZConfig/injector/Injector.cpp
+++ b/2EZConfig/injector/Injector.cpp
@@ -111,6 +111,32 @@ int Injector::Inject(char* exename) {
         writeProcessMemory(hProcess, dllAddr, dll);
 
         createRemoteThreadMethod(hProcess, llAddr, dllAddr);
+        
+		char addlDlls[255];
+		GetPrivateProfileStringA("Settings", "AdditionalDLLs", NULL, addlDlls, 255, config);
+		if (addlDlls != NULL) {
+			char addlDllName[64];
+			char* pDllNameStart = addlDlls;
+			char* pDllNameEnd;
+			bool finalDll = false;
+
+			do {
+				// Returns pointer to comma, or NULL if one doesn't exist
+				pDllNameEnd = strpbrk(pDllNameStart, ",");
+				if (pDllNameEnd == NULL) {
+					pDllNameEnd = pDllNameStart + strlen(pDllNameStart);
+					finalDll = true;
+				}
+				strncpy_s(addlDllName, pDllNameStart, pDllNameEnd - pDllNameStart);
+
+				dllAddr = virtualAlloc(hProcess, addlDllName);
+				writeProcessMemory(hProcess, dllAddr, addlDllName);
+				createRemoteThreadMethod(hProcess, llAddr, dllAddr);
+				
+				pDllNameStart = pDllNameEnd + 1;
+			} while (finalDll == false);
+		}
+		
         CloseHandle(hProcess);
         return 1;
     }

--- a/2EZConfig/injector/Injector.cpp
+++ b/2EZConfig/injector/Injector.cpp
@@ -112,30 +112,30 @@ int Injector::Inject(char* exename) {
 
         createRemoteThreadMethod(hProcess, llAddr, dllAddr);
         
-		char addlDlls[255];
-		GetPrivateProfileStringA("Settings", "AdditionalDLLs", NULL, addlDlls, 255, config);
-		if (addlDlls != NULL) {
-			char addlDllName[64];
-			char* pDllNameStart = addlDlls;
-			char* pDllNameEnd;
-			bool finalDll = false;
+	char addlDlls[255];
+	GetPrivateProfileStringA("Settings", "AdditionalDLLs", NULL, addlDlls, 255, config);
+	if (addlDlls != NULL) {
+		char addlDllName[64];
+		char* pDllNameStart = addlDlls;
+		char* pDllNameEnd;
+		bool finalDll = false;
 
-			do {
-				// Returns pointer to comma, or NULL if one doesn't exist
-				pDllNameEnd = strpbrk(pDllNameStart, ",");
-				if (pDllNameEnd == NULL) {
-					pDllNameEnd = pDllNameStart + strlen(pDllNameStart);
-					finalDll = true;
-				}
-				strncpy_s(addlDllName, pDllNameStart, pDllNameEnd - pDllNameStart);
+		do {
+			// Returns pointer to comma, or NULL if one doesn't exist
+			pDllNameEnd = strpbrk(pDllNameStart, ",");
+			if (pDllNameEnd == NULL) {
+				pDllNameEnd = pDllNameStart + strlen(pDllNameStart);
+				finalDll = true;
+			}
+			strncpy_s(addlDllName, pDllNameStart, pDllNameEnd - pDllNameStart);
 
-				dllAddr = virtualAlloc(hProcess, addlDllName);
-				writeProcessMemory(hProcess, dllAddr, addlDllName);
-				createRemoteThreadMethod(hProcess, llAddr, dllAddr);
-				
-				pDllNameStart = pDllNameEnd + 1;
-			} while (finalDll == false);
-		}
+			dllAddr = virtualAlloc(hProcess, addlDllName);
+			writeProcessMemory(hProcess, dllAddr, addlDllName);
+			createRemoteThreadMethod(hProcess, llAddr, dllAddr);
+			
+			pDllNameStart = pDllNameEnd + 1;
+		} while (finalDll == false);
+	}
 		
         CloseHandle(hProcess);
         return 1;


### PR DESCRIPTION
Hi, I added support for adding extra DLLs to the injector. In case other tools get released in the future (wink wink nudge nudge) having an easy way to use them I think would be much more convenient than trying to do things manually. How you ultimately want to implement this is up to you, but what made sense to me was adding a new settings string to 2EZ.ini with a comma-separated list of files. I haven't tested this super thoroughly yet, but I haven't noticed any issues with the game or any of the injected files so far. 